### PR TITLE
use `docker buildx` to cross compile docker images for all required architectures

### DIFF
--- a/grafana/build-images.sh
+++ b/grafana/build-images.sh
@@ -1,10 +1,6 @@
-ARCH=$1
-if [ "$ARCH" == "" ]; then
-  echo "specify arch: $ARCHS"
-  exit 1
-fi
+PLATFORMS="linux/armhf,linux/arm64,linux/amd64"
 
-VER=$2
+VER=$1
 
 if [ "$VER" == "" ]; then
   echo "specify version"
@@ -15,17 +11,7 @@ REPO=victronenergy
 TARGET=venus-docker-grafana
 BUILD_OPTS=--no-cache
 TAG_LATEST=0
-ARCHS="armhf amd64"
 
-ARCH_TAGS=""
-for arch in $ARCHS
-do
-    ARCH_TAGS="$ARCH_TAGS $REPO/$TARGET:${arch}-${VER}"
-done
+TAG="$REPO/$TARGET:${VER}"
 
-docker build ${BUILD_OPTS} $PLATFORM -t $REPO/$TARGET:${ARCH}-${VER} .
-docker push $REPO/$TARGET:${ARCH}-${VER}
-
-docker manifest create $REPO/$TARGET:$VER $ARCH_TAGS
-docker manifest push $REPO/$TARGET:$VER
-rm -rf ~/.docker/manifests/docker.io_${REPO}_${TARGET}-${VER}
+docker buildx build ${BUILD_OPTS} --platform $PLATFORMS -t ${TAG} --push .

--- a/server/build-images.sh
+++ b/server/build-images.sh
@@ -1,12 +1,6 @@
-ARCHS="armhf amd64"
+PLATFORMS="linux/armhf,linux/arm64,linux/amd64"
 
-ARCH=$1
-if [ "$ARCH" == "" ]; then
-  echo "specify arch: $ARCHS"
-  exit 1
-fi
-
-VER=$2
+VER=$1
 
 if [ "$VER" == "" ]; then
   echo "specify version"
@@ -18,16 +12,7 @@ TARGET=venus-docker-server
 BUILD_OPTS=--no-cache
 TAG_LATEST=0
 
-ARCH_TAGS=""
-for arch in $ARCHS
-do
-    ARCH_TAGS="$ARCH_TAGS $REPO/$TARGET:${arch}-${VER}"
-done
+TAG="$REPO/$TARGET:${VER}"
 
 cd docker
-docker build ${BUILD_OPTS} $PLATFORM -t $REPO/$TARGET:${ARCH}-${VER} .
-docker push $REPO/$TARGET:${ARCH}-${VER}
-
-docker manifest create $REPO/$TARGET:$VER $ARCH_TAGS
-docker manifest push $REPO/$TARGET:$VER
-rm -rf ~/.docker/manifests/docker.io_${REPO}_${TARGET}-${VER}
+docker buildx build ${BUILD_OPTS} --platform $PLATFORMS -t ${TAG} --push .


### PR DESCRIPTION
I have modified the `build-images.sh` scripts to use the `docker buildx` command to cross compile the docker images for all required architectures and push them to docker hub.

I have also added `linux/arm64` architecture that is required to run the Venus + Grafana + Server on Apple M1/M2 based Macs.

This makes is more time consuming to actually rebuild the images on limited systems like Raspberry PI, but it makes it super easy to build and tag one combined image for all platforms.

This should address #11 and #12.

I have rebuilt and pushed the images into my docker hub for examination.
-  https://hub.docker.com/repository/docker/sodaengine/venus-docker-grafana/general
-  https://hub.docker.com/repository/docker/sodaengine/venus-docker-server/general 

feel free to use the images in your own `docker-compose.yaml` by following the example below. Note that I do not use docker volumes to store data, but rather a bind mount to store everything related on external USB drive. I also explicitly run all services under aid:gid of 1000:1000 which is the user/group `pi:pi` on Raspberry PI.

Here is my `docker-compose.yaml`

```
version: '3.4'
services:
  server:
    image: "sodaengine/venus-docker-server:latest"
    ports:
     - "8088:8088"
    user: 1000:1000
    volumes:
     - type: bind
       source: /mnt/lacie/venus-docker-grafana/config
       target: /config
    depends_on:
     - upnp
     - influxdb
  upnp:
    image: "victronenergy/venus-docker-upnp:latest"
    network_mode: host
  influxdb:
    image: "influxdb:1.7"
    ports:
     - "8086:8086"
    user: 1000:1000
    volumes:
     - type: bind
       source: /mnt/lacie/venus-docker-grafana/influxdb
       target: /var/lib/influxdb
    environment:
     - INFLUXDB_HTTP_LOG_ENABLED=false
  graphing:
    image: "sodaengine/venus-docker-grafana:latest"
    volumes:
     - type: bind
       source: /mnt/lacie/venus-docker-grafana/grafana
       target: /var/lib/grafana
    ports:
     - "3000:3000"
    user: 1000:1000
    depends_on:
     - server
     - influxdb

```