### PR TITLE
cleanup docker build, run as node, add server healthcheck

### DIFF
--- a/server/docker-server/Dockerfile
+++ b/server/docker-server/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:16
+
+EXPOSE 8088/TCP
+
+RUN npm install -g --unsafe-perm venus-docker-grafana-server
+
+RUN mkdir /config
+RUN chown -R node:node /config
+
+USER node
+
+CMD [ "venus-server", "--external-upnp" ]
+
+HEALTHCHECK --interval=10s --timeout=10s --start-period=5s CMD curl -f http://localhost:8088

--- a/server/docker-server/build-images.sh
+++ b/server/docker-server/build-images.sh
@@ -1,0 +1,16 @@
+PLATFORMS="linux/armhf,linux/arm64,linux/amd64"
+
+VER=$1
+
+if [ "$VER" == "" ]; then
+  echo "specify version"
+  exit 1
+fi
+
+REPO=victronenergy
+TARGET=venus-docker-server
+BUILD_OPTS=--no-cache
+
+TAG="$REPO/$TARGET:${VER}"
+
+docker buildx build ${BUILD_OPTS} --pull --progress=plain --platform $PLATFORMS -t ${TAG} --push .

--- a/server/docker-upnp/Dockerfile
+++ b/server/docker-upnp/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:16
+
+RUN npm install -g --unsafe-perm venus-docker-grafana-server
+
+WORKDIR "/usr/local/lib/node_modules/venus-docker-grafana-server"
+
+USER node
+
+CMD [ "node", "lib/upnp.js" ]

--- a/server/docker-upnp/build-images.sh
+++ b/server/docker-upnp/build-images.sh
@@ -8,11 +8,9 @@ if [ "$VER" == "" ]; then
 fi
 
 REPO=victronenergy
-TARGET=venus-docker-server
+TARGET=venus-docker-upnp
 BUILD_OPTS=--no-cache
-TAG_LATEST=0
 
 TAG="$REPO/$TARGET:${VER}"
 
-cd docker
-docker buildx build ${BUILD_OPTS} --platform $PLATFORMS -t ${TAG} --push .
+docker buildx build ${BUILD_OPTS} --pull --progress=plain --platform $PLATFORMS -t ${TAG} --push .

--- a/server/docker/Dockerfile
+++ b/server/docker/Dockerfile
@@ -1,9 +1,0 @@
-FROM node:8
-
-EXPOSE 8088/TCP
-
-RUN npm install -g --unsafe-perm venus-docker-grafana-server
-
-RUN mkdir /config
-
-CMD [ "venus-server", "--external-upnp" ]


### PR DESCRIPTION
The PR cleans up build process for:

- venus-docker-server
- venus-docker-upnp

docker images. It continues to use the published stable `venus-docker-grafana-server` npm package, but cleans up couple of issues:

1. Both docker images `venus-docker-server`, and `venus-docker-upnp` will now run the internal node process as `node` user, instead of `root`. 
2. `venus-docker-server` image provides a `HEALTHCHECK` command so that other containers can wait for the server to startup fully. This is important especially on slower devices such as Raspberry Pi.

Please do not merge yet...